### PR TITLE
Include time in the log output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.24
 
 require (
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/mattn/go-isatty v0.0.20
 	github.com/muesli/termenv v0.16.0
 	github.com/stretchr/testify v1.10.0
 )
@@ -17,6 +16,7 @@ require (
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/style.go
+++ b/style.go
@@ -14,6 +14,7 @@ type Style struct {
 	LevelLabels       map[slog.Level]lipgloss.Style // required
 	MultilinePrefix   lipgloss.Style                // required
 	PrefixDelimiter   lipgloss.Style                // required
+	Time              lipgloss.Style                // required
 
 	Messages map[slog.Level]lipgloss.Style
 	Values   map[string]lipgloss.Style
@@ -28,6 +29,7 @@ func DefaultStyle() *Style {
 		KeyValueDelimiter: lipgloss.NewStyle().SetString("=").Faint(true),
 		MultilinePrefix:   lipgloss.NewStyle().SetString("| ").Faint(true),
 		PrefixDelimiter:   lipgloss.NewStyle().SetString(": "),
+		Time:              lipgloss.NewStyle().Faint(true),
 		LevelLabels: map[slog.Level]lipgloss.Style{
 			slog.LevelDebug: lipgloss.NewStyle().SetString("DBG"),                                  // default
 			slog.LevelInfo:  lipgloss.NewStyle().SetString("INF").Foreground(lipgloss.Color("10")), // green
@@ -48,6 +50,7 @@ func PlainStyle() *Style {
 	return &Style{
 		KeyValueDelimiter: lipgloss.NewStyle().SetString("="),
 		MultilinePrefix:   lipgloss.NewStyle().SetString("  | "),
+		Time:              lipgloss.NewStyle(),
 		PrefixDelimiter:   lipgloss.NewStyle().SetString(": "),
 		LevelLabels: map[slog.Level]lipgloss.Style{
 			slog.LevelDebug: lipgloss.NewStyle().SetString("DBG"),


### PR DESCRIPTION
Includes the current time as the first line of log output by default.
Format defaults to kitchen time, but can be set to any format.

Adds ReplaceAttr option to allow skipping or replacing the time.