### PR TITLE
Options => HandlerOptions, tests, docs

### DIFF
--- a/concurrency_test.go
+++ b/concurrency_test.go
@@ -15,7 +15,7 @@ import (
 func TestHandler_concurrentWrites(t *testing.T) {
 	var buffer strings.Builder
 
-	handler := silog.NewHandler(&buffer, &silog.Options{
+	handler := silog.NewHandler(&buffer, &silog.HandlerOptions{
 		Style: silog.PlainStyle(),
 	})
 	logger := slog.New(handler)

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,67 @@
+package silog_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/charmbracelet/lipgloss"
+	"go.abhg.dev/log/silog"
+)
+
+// Demonstrates how to introduce a new log level to the logger.
+func Example_customLevel() {
+	const LevelTrace = slog.LevelDebug - 4
+
+	style := silog.PlainStyle()
+	style.LevelLabels[LevelTrace] = style.LevelLabels[slog.LevelDebug].SetString("TRC")
+	style.Messages[LevelTrace] = style.Messages[slog.LevelDebug]
+
+	handler := silog.NewHandler(os.Stdout, &silog.HandlerOptions{
+		Style: style,
+		Level: LevelTrace,
+		// To keep the test output clean easy to test,
+		// we will not log the time in this example.
+		ReplaceAttr: skipTime,
+	})
+
+	logger := slog.New(handler)
+	logger.Log(context.Background(), LevelTrace, "This is a trace message")
+	logger.Debug("This is a debug message")
+
+	// Output:
+	// TRC This is a trace message
+	// DBG This is a debug message
+}
+
+// Demonstrates reserving a log level to be logged without a label before it.
+func Example_noLogLabel() {
+	const LevelPlain = slog.LevelDebug - 1
+
+	style := silog.PlainStyle()
+	style.LevelLabels[LevelPlain] = lipgloss.NewStyle() // No label
+	style.Messages[LevelPlain] = style.Messages[slog.LevelDebug]
+
+	handler := silog.NewHandler(os.Stdout, &silog.HandlerOptions{
+		Style: style,
+		Level: LevelPlain,
+		// To keep the test output clean easy to test,
+		// we will not log the time in this example.
+		ReplaceAttr: skipTime,
+	})
+
+	logger := slog.New(handler)
+	logger.Log(context.Background(), LevelPlain, "This is a plain message")
+	logger.Debug("This is a debug message")
+
+	// Output:
+	// This is a plain message
+	// DBG This is a debug message
+}
+
+func skipTime(groups []string, attr slog.Attr) slog.Attr {
+	if len(groups) == 0 && attr.Key == slog.TimeKey {
+		return slog.Attr{}
+	}
+	return attr
+}

--- a/handler.go
+++ b/handler.go
@@ -13,8 +13,8 @@ import (
 	"time"
 )
 
-// Options defines options for the logger.
-type Options struct {
+// HandlerOptions defines options for constructing a [Handler].
+type HandlerOptions struct {
 	// Level is the minimum log level to log.
 	// It must be one of the supported log levels.
 	// The default is LevelInfo.
@@ -85,8 +85,8 @@ var _ slog.Handler = (*Handler)(nil)
 // and is safe to use from multiple goroutines.
 // Each log message is posted to the output writer
 // in a single Writer.Write call.
-func NewHandler(w io.Writer, opts *Options) *Handler {
-	opts = cmp.Or(opts, &Options{})
+func NewHandler(w io.Writer, opts *HandlerOptions) *Handler {
+	opts = cmp.Or(opts, &HandlerOptions{})
 	style := cmp.Or(opts.Style, DefaultStyle())
 	timeFormat := cmp.Or(opts.TimeFormat, time.Kitchen)
 
@@ -407,7 +407,7 @@ func (f *attrFormatter) FormatAttr(attr slog.Attr) {
 
 	valueStyle, hasStyle := f.style.Values[attr.Key]
 	if isMultiline {
-		prefixStyle := f.style.MultilinePrefix
+		prefixStyle := f.style.MultilineValuePrefix
 		if hasStyle {
 			prefixStyle = prefixStyle.Foreground(valueStyle.GetForeground())
 		}

--- a/handler_slog_test.go
+++ b/handler_slog_test.go
@@ -15,7 +15,7 @@ func TestLogHandler_slogtest(t *testing.T) {
 	slogtest.Run(t, func(*testing.T) slog.Handler {
 		buffer.Reset()
 
-		return NewHandler(&buffer, &Options{
+		return NewHandler(&buffer, &HandlerOptions{
 			Level:      slog.LevelDebug,
 			Style:      PlainStyle(),
 			TimeFormat: time.RFC3339,

--- a/handler_test.go
+++ b/handler_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestHandler_formatting(t *testing.T) {
 	var buffer strings.Builder
-	handler := silog.NewHandler(&buffer, &silog.Options{
+	handler := silog.NewHandler(&buffer, &silog.HandlerOptions{
 		Level: slog.LevelDebug,
 		Style: silog.PlainStyle(),
 		ReplaceAttr: func(groups []string, attr slog.Attr) slog.Attr {
@@ -306,7 +306,7 @@ func TestHandler_formatting(t *testing.T) {
 
 func TestHandler_WithLevel(t *testing.T) {
 	var buffer strings.Builder
-	handler := silog.NewHandler(&buffer, &silog.Options{
+	handler := silog.NewHandler(&buffer, &silog.HandlerOptions{
 		ReplaceAttr: func(groups []string, attr slog.Attr) slog.Attr {
 			if len(groups) == 0 && attr.Key == slog.TimeKey {
 				return slog.Attr{}
@@ -369,7 +369,7 @@ func TestHandler_Enabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := silog.NewHandler(io.Discard, &silog.Options{
+			h := silog.NewHandler(io.Discard, &silog.HandlerOptions{
 				Level: tt.leveler,
 				Style: silog.PlainStyle(),
 			})
@@ -390,7 +390,7 @@ func TestHandler_withAttrsConcurrent(t *testing.T) {
 	)
 
 	var buffer strings.Builder
-	log := slog.New(silog.NewHandler(&buffer, &silog.Options{
+	log := slog.New(silog.NewHandler(&buffer, &silog.HandlerOptions{
 		Level: slog.LevelDebug,
 		Style: silog.PlainStyle(),
 	}))
@@ -426,7 +426,7 @@ func TestHandler_multilineMessageStyling(t *testing.T) {
 	style.Messages[slog.LevelInfo] = lipgloss.NewStyle().Bold(true)
 
 	var buffer strings.Builder
-	log := slog.New(silog.NewHandler(&buffer, &silog.Options{
+	log := slog.New(silog.NewHandler(&buffer, &silog.HandlerOptions{
 		Level: slog.LevelDebug,
 		Style: style,
 		ReplaceAttr: func(groups []string, attr slog.Attr) slog.Attr {

--- a/style.go
+++ b/style.go
@@ -7,29 +7,86 @@ import (
 )
 
 // Style defines the output styling for the logger.
+//
+// Any fields of style that are not set will use the default style
+// (no color, no special formatting).
+//
+// # Customization
+//
+// It's best to construct a style with [DefaultStyle] or [PlainStyle]
+// and then modify the fields you want to change.
+// For example:
+//
+//	style := silog.DefaultStyle()
+//	style.KeyValueDelimiter = lipgloss.NewStyle().SetString(": ")
 type Style struct {
+	// Key is the style used for the key in key-value pairs.
 	Key lipgloss.Style
 
-	KeyValueDelimiter lipgloss.Style                // required
-	LevelLabels       map[slog.Level]lipgloss.Style // required
-	MultilinePrefix   lipgloss.Style                // required
-	PrefixDelimiter   lipgloss.Style                // required
-	Time              lipgloss.Style                // required
+	// KeyValueDelimiter is the style used for the delimiter
+	// separating keys and values in key-value pairs.
+	//
+	// This SHOULD have a non-empty value (e.g. "=", ": ", etc.)
+	// set with lipgloss.Style.SetString.
+	//
+	// The default value is "=".
+	KeyValueDelimiter lipgloss.Style
 
+	// LevelLabels is a map of slog.Level to style
+	// for the label of that level.
+	//
+	// Each style here SHOULD have a non-empty value
+	// (e.g. "DBG", "INF", etc.) set with lipgloss.Style.SetString.
+	//
+	// If a record has a level that is not present in this map,
+	// messages of that level will not be labeled.
+	LevelLabels map[slog.Level]lipgloss.Style
+
+	// MultilineValuePrefix defines the style for the prefix that is
+	// prepended to each line of an indented multi-line attribute value.
+	//
+	// This SHOULD have a non-empty value (e.g. "| ").
+	// The default value is "| ".
+	MultilineValuePrefix lipgloss.Style
+
+	// PrefixDelimiter defines the style separating a prefix
+	// (specified with Handler.WithPrefix) from the rest of the log message.
+	//
+	// This SHOULD have a non-empty value (e.g. ": ", " - ", etc.)
+	// The default value is ": ".
+	PrefixDelimiter lipgloss.Style
+
+	// Time defines the style used for the time of a log record.
+	//
+	// If ReplaceAttr is used to change the time attribute,
+	// the style is also used for the replacement value.
+	Time lipgloss.Style
+
+	// Messages defines styling for messages logged at different levels.
+	//
+	// If a log record has a level that is not present in this map,
+	// the message will use plain text style.
 	Messages map[slog.Level]lipgloss.Style
-	Values   map[string]lipgloss.Style
+
+	// Values defines the styling for attributes matched by their keys.
+	// Attributes with keys that are not present in this map
+	// will use a plain text style for their values.
+	//
+	// DefaultStyle uses this to style the "error" key in red.
+	Values map[string]lipgloss.Style
 }
 
 // TODO: lipgloss.Renderer-based style
 
-// DefaultStyle returns the default style for the logger.
+// DefaultStyle is the default style used by [Handler].
+// It provides colored output, faint text for debug messages, red errors, etc.
 func DefaultStyle() *Style {
 	return &Style{
-		Key:               lipgloss.NewStyle().Faint(true),
-		KeyValueDelimiter: lipgloss.NewStyle().SetString("=").Faint(true),
-		MultilinePrefix:   lipgloss.NewStyle().SetString("| ").Faint(true),
-		PrefixDelimiter:   lipgloss.NewStyle().SetString(": "),
-		Time:              lipgloss.NewStyle().Faint(true),
+		Key:                  lipgloss.NewStyle().Faint(true),
+		KeyValueDelimiter:    lipgloss.NewStyle().SetString("=").Faint(true),
+		MultilineValuePrefix: lipgloss.NewStyle().SetString("| ").Faint(true),
+		PrefixDelimiter:      lipgloss.NewStyle().SetString(": "),
+		Time:                 lipgloss.NewStyle().Faint(true),
 		LevelLabels: map[slog.Level]lipgloss.Style{
 			slog.LevelDebug: lipgloss.NewStyle().SetString("DBG"),                                  // default
 			slog.LevelInfo:  lipgloss.NewStyle().SetString("INF").Foreground(lipgloss.Color("10")), // green
@@ -45,13 +102,14 @@ func DefaultStyle() *Style {
 	}
 }
 
-// PlainStyle returns a style for the logger without any colors.
+// PlainStyle is a style for [Handler] that performs no styling.
+// It's best when writing to a non-terminal destination.
 func PlainStyle() *Style {
 	return &Style{
-		KeyValueDelimiter: lipgloss.NewStyle().SetString("="),
-		MultilinePrefix:   lipgloss.NewStyle().SetString("  | "),
-		Time:              lipgloss.NewStyle(),
-		PrefixDelimiter:   lipgloss.NewStyle().SetString(": "),
+		KeyValueDelimiter:    lipgloss.NewStyle().SetString("="),
+		MultilineValuePrefix: lipgloss.NewStyle().SetString("  | "),
+		Time:                 lipgloss.NewStyle(),
+		PrefixDelimiter:      lipgloss.NewStyle().SetString(": "),
 		LevelLabels: map[slog.Level]lipgloss.Style{
 			slog.LevelDebug: lipgloss.NewStyle().SetString("DBG"),
 			slog.LevelInfo:  lipgloss.NewStyle().SetString("INF"),

--- a/style_test.go
+++ b/style_test.go
@@ -14,13 +14,13 @@ func TestDefaultStyle(t *testing.T) {
 	assertHasValue := func(t *testing.T, style lipgloss.Style, msgArgs ...any) {
 		t.Helper()
 
-		assert.NotEmpty(t, strings.TrimSpace(style.String()), msgArgs...)
+		assert.NotEmpty(t, strings.TrimSpace(style.Value()), msgArgs...)
 	}
 
 	style := silog.DefaultStyle()
 
 	assertHasValue(t, style.KeyValueDelimiter, "KeyValueDelimiter")
-	assertHasValue(t, style.MultilinePrefix, "MultilinePrefix")
+	assertHasValue(t, style.MultilineValuePrefix, "MultilinePrefix")
 	assertHasValue(t, style.PrefixDelimiter, "PrefixDelimiter")
 
 	defaultLevels := []slog.Level{


### PR DESCRIPTION
Rename Options to HandlerOptions (easier to drop-in for slog options),
add more documentation around styling and a couple examples.