### PR TITLE
WithPrefix => SetPrefix

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -59,7 +59,7 @@ func Example_noLabel() {
 	// DBG This is a debug message
 }
 
-func ExampleHandler_WithPrefix() {
+func ExampleHandler_SetPrefix() {
 	handler := silog.NewHandler(os.Stdout, &silog.HandlerOptions{
 		Style: silog.PlainStyle(),
 		// To keep the test output clean easy to test,
@@ -67,11 +67,15 @@ func ExampleHandler_WithPrefix() {
 		ReplaceAttr: skipTime,
 	})
 
-	logger := slog.New(handler.WithPrefix("example"))
-	logger.Info("This is an info message")
+	h1 := handler.SetPrefix("example")
+	h2 := h1.SetPrefix("")
+
+	slog.New(h1).Info("Single prefix")
+	slog.New(h2).Info("No prefix")
 
 	// Output:
-	// INF example: This is an info message
+	// INF example: Single prefix
+	// INF No prefix
 }
 
 func ExampleHandler_WithLevelOffset() {

--- a/handler.go
+++ b/handler.go
@@ -266,17 +266,26 @@ func (h *Handler) WithGroup(name string) slog.Handler {
 // retaining all other attributes and groups.
 //
 // It will write to the same output writer as this handler.
-func (h *Handler) WithLevel(lvl slog.Leveler) slog.Handler {
+func (h *Handler) WithLevel(lvl slog.Leveler) *Handler {
 	newH := *h
 	newH.lvl = lvl
 	return &newH
 }
 
-// WithPrefix returns a new handler with the given prefix
-func (h *Handler) WithPrefix(prefix string) slog.Handler {
+// SetPrefix returns a copy of this handler
+// that will use the given prefix for each log message.
+//
+// If the handler already has a prefix,
+// this will replace it with the new prefix.
+func (h *Handler) SetPrefix(prefix string) *Handler {
 	newH := *h
 	newH.prefix = prefix
 	return &newH
+}
+
+// Prefix returns the current prefix for this handler, if any.
+func (h *Handler) Prefix() string {
+	return h.prefix
 }
 
 // WithLevelOffset returns a copy of this handler
@@ -297,7 +306,7 @@ func (h *Handler) WithPrefix(prefix string) slog.Handler {
 //	slog.LevelDebug -> slog.LevelDebug - 4
 //
 // Any existing level offset is retained, so this operation is additive.
-func (h *Handler) WithLevelOffset(n int) slog.Handler {
+func (h *Handler) WithLevelOffset(n int) *Handler {
 	newH := *h
 	newH.lvlOffset += n
 	return &newH

--- a/handler_test.go
+++ b/handler_test.go
@@ -253,14 +253,14 @@ func TestHandler_formatting(t *testing.T) {
 	})
 
 	t.Run("Prefix", func(t *testing.T) {
-		log := slog.New(handler.WithPrefix("prefix"))
+		log := slog.New(handler.SetPrefix("prefix"))
 
 		log.Info("foo")
 		assertLinesWithTime(t, "9:45AM INF prefix: foo")
 	})
 
 	t.Run("MultilineMessageWithPrefix", func(t *testing.T) {
-		log := slog.New(handler.WithPrefix("prefix"))
+		log := slog.New(handler.SetPrefix("prefix"))
 
 		log.Info("foo\nbar\nbaz")
 		assertLinesWithTime(t,


### PR DESCRIPTION
As prefix is a replace operation, not a chain operation,
rename it to SetPrefix and add a means of getting the current prefix.