### PR TITLE
test: use WaitGroup.Go in TestHandler_withAttrsConcurrent

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -427,17 +427,14 @@ func TestHandler_withAttrsConcurrent(t *testing.T) {
 	var ready, done sync.WaitGroup
 	ready.Add(NumWorkers)
 	for range NumWorkers {
-		done.Add(1)
-		go func() {
-			defer done.Done()
-
+		done.Go(func() {
 			ready.Done()
 			ready.Wait()
 
 			for i := range NumWrites {
 				log.Info("message", "i", i)
 			}
-		}()
+		})
 	}
 
 	done.Wait()


### PR DESCRIPTION
### Motivation
- Resolve a `golangci-lint` `modernize` warning by replacing a manual goroutine creation pattern with `sync.WaitGroup.Go` in the concurrent handler test.

### Description
- Replace the `done.Add(1); go func() { defer done.Done(); ... }()` pattern with `done.Go(func() { ... })` in `TestHandler_withAttrsConcurrent` inside `handler_test.go`, preserving the existing `ready` synchronization and logging loop.

### Testing
- Ran `mise run lint`; the lint run could not complete because `mise` failed to download required tools due to outbound network/tunnel errors, so lint verification could not be performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e00a018b788324bc3148018534ec96)